### PR TITLE
Fix Unhandled exception on request.query

### DIFF
--- a/lib/src/http/request/request.dart
+++ b/lib/src/http/request/request.dart
@@ -190,7 +190,7 @@ class Request {
       return _query.values;
     }
 
-    if (_query[key]) {
+    if (_query[key] != null) {
       return _query[key];
     }
 


### PR DESCRIPTION
Fix Unhandled exception : type 'String' is not a subtype of type 'bool' on request.query