### PR TITLE
fix: add toString to token digest causing type error on postgres

### DIFF
--- a/lib/src/authentication/authentication.dart
+++ b/lib/src/authentication/authentication.dart
@@ -51,7 +51,7 @@ class Auth {
       await PersonalAccessTokens().query().insert({
         'name': _userGuard,
         'tokenable_id': _user[_userGuard]['id'],
-        'token': md5.convert(utf8.encode(token['access_token'])),
+        'token': md5.convert(utf8.encode(token['access_token'])).toString(),
         'created_at': DateTime.now(),
       });
     }


### PR DESCRIPTION
Hello, it was causing an error in postgres:

`"PostgreSQLSeverity.error : Could not infer type of value 'dbba51458ece56eb1056aa84d68e8184'`

now it works!

happy to help!