### PR TITLE
Add redirect method and custom 404 error handling

### DIFF
--- a/lib/src/http/response/response.dart
+++ b/lib/src/http/response/response.dart
@@ -7,6 +7,7 @@ import 'package:vania/src/http/response/stream_file.dart';
 enum ResponseType {
   json,
   none,
+  redirect,
   html,
   sse,
   streamFile,
@@ -53,7 +54,7 @@ class Response {
     res.statusCode = httpStatusCode;
     if (headers.isNotEmpty) {
       headers.forEach((key, value) {
-        res.headers.add(key, value);
+        res.headers.set(key, value);
       });
     }
     switch (responseType) {
@@ -105,11 +106,19 @@ class Response {
         res.headers.add("Content-Disposition", stream.contentDisposition);
         res.addStream(stream.stream!).then((_) => res.close());
         break;
+      case ResponseType.redirect:
+        res.headers.set(HttpHeaders.locationHeader, data);
+        await res.close();
       default:
         res.write(data);
         await res.close();
     }
   }
+
+  static redirect(String location) => Response(
+      responseType: ResponseType.redirect,
+      data: location,
+      httpStatusCode: HttpStatus.found);
 
   static json(
     dynamic jsonData, [

--- a/lib/src/route/route_handler.dart
+++ b/lib/src/route/route_handler.dart
@@ -26,6 +26,13 @@ RouteData? httpRouteHandler(HttpRequest req) {
             responseType: ResponseType.json,
           );
         } else {
+          Directory errorsDirectory = Directory('errors');
+          if (errorsDirectory.existsSync()) {
+            File errorFile = File('errors/404.html');
+            if (errorFile.existsSync()) {
+              throw NotFoundException(message: errorFile.readAsStringSync());
+            }
+          }
           throw NotFoundException();
         }
       }


### PR DESCRIPTION

1. **Add redirect method (#144)**:  
   - A new `redirect` method is added to the `Response` class to simplify HTTP redirections.

2. **Add custom 404 error handling via HTML file (#145)**:  
   - Custom handling for 404 errors is implemented, serving a user-defined HTML page when a page is not found, enhancing the error-handling experience. 
   - To enable this feature, create an `errors` directory in the root of the project.
   - Inside the `errors` directory, create a `404.html` file at `errors/404.html`.
   - This approach enhances the error-handling experience, providing a more user-friendly response for missing pages.

**Errors directory placement:**

```
- lib
- errors
    --- 404.html
```