### PR TITLE
Add DatabaseException logging to MigrationConnection setup

### DIFF
--- a/lib/src/database/migration/migration_connection.dart
+++ b/lib/src/database/migration/migration_connection.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import '../../contract/database/_connectors/_database_connection.dart';
 import '../../env_handler/env.dart';
+import '../../exception/database_exception.dart';
 import '../../exception/invalid_argument_exception.dart';
 import '../_connection_manager.dart';
 import '../_database_utils/_db_config.dart';
@@ -61,6 +62,10 @@ class MigrationConnection implements MigrationConnectionInterface {
       await _dbConnection!.execute(migrationSql);
     } on InvalidArgumentException catch (e) {
       stderr.writeln(e.message);
+      exit(1);
+    } on DatabaseException catch (e) {
+      stderr.writeln(e.message);
+      stderr.writeln(e.cause);
       exit(1);
     } catch (e) {
       stderr.write(e.toString());


### PR DESCRIPTION
**Summary**  
This PR improves error handling during database migrations by adding explicit logging for `DatabaseException` in the `MigrationConnection.setup` method.

**Details**
•  Introduced a `DatabaseException` catch block in `MigrationConnection.setup`.
•  Logs both `e.message` and `e.cause` to `stderr`.
•  Exits the process with status code 1 to signal failure.

**Why this change?**
Previously, database migration errors could fail silently or without sufficient context, making debugging difficult. With this update:

•  Developers receive clear error messages directly in the console.
•  The process exits immediately, preventing further execution in an invalid state.
•  Improves reliability and developer experience when running migrations.

**Example Output**
```bash
Migration started 
Database connection failed
MySQLClientException: Auth plugin caching_sha2_password is supported only with secure connections. Pass secure: true or use another auth method
```

**Impact**
•  No breaking changes to existing APIs.
•  Improves observability and debugging during migrations.