### PR TITLE
Fix: Explicitly cast jwt.payload to Map<String, dynamic> in HasApiTokens

### DIFF
--- a/lib/src/authentication/has_api_tokens.dart
+++ b/lib/src/authentication/has_api_tokens.dart
@@ -130,11 +130,16 @@ class HasApiTokens {
         subject: env<String?>('JWT_SUBJECT'),
       );
 
-      if (jwt.payload['type'] != expectedType) {
-        throw Unauthenticated(message: 'Invalid token');
+      final payload = jwt.payload;
+      if (payload is! Map<String, dynamic>) {
+        throw Unauthenticated(message: 'Invalid JWT payload type');
       }
 
-      return jwt.payload;
+      if (payload['type'] != expectedType) {
+        throw Unauthenticated(message: 'Invalid token type');
+      }
+
+      return payload;
     } on JWTExpiredException {
       rethrow;
     } on JWTException {


### PR DESCRIPTION
## Summary
This PR resolves Issue #201, where `jwt.payload` was incorrectly assumed to be a `Map<String, dynamic>`. In Dart SDK ≥3.4, implicit down casting from `Object` to `Map` is no longer allowed, causing compile-time errors.

## Details of the Fix
•  Added a runtime type check for `jwt.payload`.
•  If the payload is not a `Map<String, dynamic>`, an exception is thrown with a clear error message.
•  Safely cast the payload before accessing its fields.
•  Ensures compatibility with Dart’s stricter type system.

## Impact
•  No breaking changes to public APIs.
•  Safer and more reliable JWT validation logic.
•  Developers using Dart 3.4+ can now run Vania projects without type errors.